### PR TITLE
Add support for boolean datatype

### DIFF
--- a/.changeset/cuddly-dodos-hope.md
+++ b/.changeset/cuddly-dodos-hope.md
@@ -1,0 +1,5 @@
+---
+"d1-orm": minor
+---
+
+Support for boolean datatype

--- a/guides/models.md
+++ b/guides/models.md
@@ -42,6 +42,10 @@ const users = new Model<User>(
 			type: DataTypes.STRING,
 			unique: true,
 		},
+		validated: {
+			type: DataTypes.BOOLEAN,
+			defaultValue: false,
+		},
 	}
 );
 ```
@@ -76,6 +80,8 @@ That's it! You've now created a model. You can now use the model to query the da
 
 There are two ways of selecting data from the database. The first is to use the {@link Model.First} method which will return one result, and the second is to use the {@link Model.All} method, which will return an array of results.
 
+All columns specified in the model as `DataTypes.BOOLEAN` will be stored in the database as `false = 0, true = 1`. Data returned will be returned typed as an integer. What this means is that if executing an equality test, an if statement will operate exactly as intended if you use a `==`. This is because a zero is a falsey value and one is a truthy value and the actual data type is not being compared. Attempting to test boolean equality with `===` will not yield the desired result as this equality check first checks the data type of the value and boolean != integer.
+
 #### First()
 
 Let's start with the {@link Model.First} method. This method will return the first result that matches the query. It takes a single argument, which is an object containing a `Where` clause. See [Query Building](/guides/query-building) for more information on how to use the `Where` clause. This should be an object with a key of the column name, and a value of the value to match.
@@ -104,6 +110,8 @@ This will return the first 10 users with a name of "John Doe", ordered by ID, eq
 ### Inserting Data
 
 There are two methods used to insert data into the database. The first is {@link Model.InsertOne}, which will insert a single row, and the second is {@link Model.InsertMany}, which will insert multiple rows. Both accept an optional boolean parameter instructing the [Query Building](/guides/query-building) to generate `INSERT or REPLACE` instead of just `INSERT`. This mechanism differs from [Upsert](/guides/upserting) by its requirement of only replacing records based on the primary key.
+
+All columns specified in the model as `DataTypes.BOOLEAN` will be stored in the database as integer values where `false = 0, true = 1`.
 
 #### InsertOne()
 

--- a/src/datatypes.ts
+++ b/src/datatypes.ts
@@ -7,7 +7,7 @@
 export enum DataTypes {
 	INTEGER = "integer",
 	INT = "integer",
-	BOOLEAN = "integer",
+	BOOLEAN = "boolean",
 	TEXT = "text",
 	STRING = "text",
 	VARCHAR = "text",

--- a/src/datatypes.ts
+++ b/src/datatypes.ts
@@ -1,9 +1,13 @@
 /**
+ * SQLite specification doesn't provide an explicit boolean data type,
+ * so boolean is converted to an integer where: 0=false, 1=true
+ *
  * @enum {string} Aliases for DataTypes used in a {@link ModelColumn} definition.
  */
 export enum DataTypes {
 	INTEGER = "integer",
 	INT = "integer",
+	BOOLEAN = "integer",
 	TEXT = "text",
 	STRING = "text",
 	VARCHAR = "text",

--- a/src/model.ts
+++ b/src/model.ts
@@ -145,7 +145,7 @@ export class Model<T extends object> {
 		orReplace = false
 	): Promise<D1Result<T>> {
 		const qt = orReplace ? QueryType.INSERT_OR_REPLACE : QueryType.INSERT;
-		const statement = GenerateQuery(qt, this.tableName, this.columns, { data });
+		const statement = GenerateQuery(qt, this.tableName, { data });
 		return this.#D1Orm
 			.prepare(statement.query)
 			.bind(...statement.bindings)
@@ -162,7 +162,7 @@ export class Model<T extends object> {
 		const qt = orReplace ? QueryType.INSERT_OR_REPLACE : QueryType.INSERT;
 		const stmts: D1PreparedStatement[] = [];
 		for (const row of data) {
-			const stmt = GenerateQuery(qt, this.tableName, this.columns, {
+			const stmt = GenerateQuery(qt, this.tableName, {
 				data: row,
 			});
 			stmts.push(this.#D1Orm.prepare(stmt.query).bind(...stmt.bindings));
@@ -179,7 +179,7 @@ export class Model<T extends object> {
 	): Promise<T | null> {
 		const statement = GenerateQuery(
 			QueryType.SELECT,
-			this.tableName, this.columns,
+			this.tableName,
 			Object.assign(options, { limit: 1 })
 		);
 		try {
@@ -202,7 +202,7 @@ export class Model<T extends object> {
 	public async All(
 		options: Omit<GenerateQueryOptions<T>, "data" | "upsertOnlyUpdateData">
 	): Promise<D1Result<T[]>> {
-		const statement = GenerateQuery(QueryType.SELECT, this.tableName, this.columns, options);
+		const statement = GenerateQuery(QueryType.SELECT, this.tableName, options);
 		return this.#D1Orm
 			.prepare(statement.query)
 			.bind(...statement.bindings)
@@ -215,7 +215,7 @@ export class Model<T extends object> {
 	public async Delete(
 		options: Pick<GenerateQueryOptions<T>, "where">
 	): Promise<D1Result<unknown>> {
-		const statement = GenerateQuery(QueryType.DELETE, this.tableName, this.columns, options);
+		const statement = GenerateQuery(QueryType.DELETE, this.tableName, options);
 		return this.#D1Orm
 			.prepare(statement.query)
 			.bind(...statement.bindings)
@@ -229,7 +229,7 @@ export class Model<T extends object> {
 	public async Update(
 		options: Pick<GenerateQueryOptions<T>, "where" | "data">
 	): Promise<D1Result<unknown>> {
-		const statement = GenerateQuery(QueryType.UPDATE, this.tableName, this.columns, options);
+		const statement = GenerateQuery(QueryType.UPDATE, this.tableName, options);
 		return this.#D1Orm
 			.prepare(statement.query)
 			.bind(...statement.bindings)
@@ -249,7 +249,7 @@ export class Model<T extends object> {
 	) {
 		const statement = GenerateQuery(
 			QueryType.UPSERT,
-			this.tableName, this.columns,
+			this.tableName,
 			options,
 			this.#primaryKeys
 		);

--- a/src/model.ts
+++ b/src/model.ts
@@ -145,7 +145,7 @@ export class Model<T extends object> {
 		orReplace = false
 	): Promise<D1Result<T>> {
 		const qt = orReplace ? QueryType.INSERT_OR_REPLACE : QueryType.INSERT;
-		const statement = GenerateQuery(qt, this.tableName, { data });
+		const statement = GenerateQuery(qt, this.tableName, this.columns, { data });
 		return this.#D1Orm
 			.prepare(statement.query)
 			.bind(...statement.bindings)
@@ -162,7 +162,7 @@ export class Model<T extends object> {
 		const qt = orReplace ? QueryType.INSERT_OR_REPLACE : QueryType.INSERT;
 		const stmts: D1PreparedStatement[] = [];
 		for (const row of data) {
-			const stmt = GenerateQuery(qt, this.tableName, {
+			const stmt = GenerateQuery(qt, this.tableName, this.columns, {
 				data: row,
 			});
 			stmts.push(this.#D1Orm.prepare(stmt.query).bind(...stmt.bindings));
@@ -179,7 +179,7 @@ export class Model<T extends object> {
 	): Promise<T | null> {
 		const statement = GenerateQuery(
 			QueryType.SELECT,
-			this.tableName,
+			this.tableName, this.columns,
 			Object.assign(options, { limit: 1 })
 		);
 		try {
@@ -202,7 +202,7 @@ export class Model<T extends object> {
 	public async All(
 		options: Omit<GenerateQueryOptions<T>, "data" | "upsertOnlyUpdateData">
 	): Promise<D1Result<T[]>> {
-		const statement = GenerateQuery(QueryType.SELECT, this.tableName, options);
+		const statement = GenerateQuery(QueryType.SELECT, this.tableName, this.columns, options);
 		return this.#D1Orm
 			.prepare(statement.query)
 			.bind(...statement.bindings)
@@ -215,7 +215,7 @@ export class Model<T extends object> {
 	public async Delete(
 		options: Pick<GenerateQueryOptions<T>, "where">
 	): Promise<D1Result<unknown>> {
-		const statement = GenerateQuery(QueryType.DELETE, this.tableName, options);
+		const statement = GenerateQuery(QueryType.DELETE, this.tableName, this.columns, options);
 		return this.#D1Orm
 			.prepare(statement.query)
 			.bind(...statement.bindings)
@@ -229,7 +229,7 @@ export class Model<T extends object> {
 	public async Update(
 		options: Pick<GenerateQueryOptions<T>, "where" | "data">
 	): Promise<D1Result<unknown>> {
-		const statement = GenerateQuery(QueryType.UPDATE, this.tableName, options);
+		const statement = GenerateQuery(QueryType.UPDATE, this.tableName, this.columns, options);
 		return this.#D1Orm
 			.prepare(statement.query)
 			.bind(...statement.bindings)
@@ -249,7 +249,7 @@ export class Model<T extends object> {
 	) {
 		const statement = GenerateQuery(
 			QueryType.UPSERT,
-			this.tableName,
+			this.tableName, this.columns,
 			options,
 			this.#primaryKeys
 		);

--- a/src/model.ts
+++ b/src/model.ts
@@ -79,7 +79,9 @@ export class Model<T extends object> {
 		const columnEntries = Object.entries(this.columns);
 		let hasAutoIncrement = false;
 		const columnDefinition = columnEntries.map(([columnName, column]) => {
-			let definition = `${columnName} ${column.type}`;
+			console.log(column.type);
+			const ct = column.type === DataTypes.BOOLEAN ? "integer" : column.type;
+			let definition = `${columnName} ${ct}`;
 			if (column.autoIncrement) {
 				hasAutoIncrement = true;
 				definition += " PRIMARY KEY AUTOINCREMENT";
@@ -91,7 +93,7 @@ export class Model<T extends object> {
 				definition += " UNIQUE";
 			}
 			if (column.defaultValue !== undefined) {
-				definition += ` DEFAULT "${column.defaultValue}"`;
+				definition += ` DEFAULT "${this.coerceTypedValue(column)}"`;
 			}
 			return definition;
 		});
@@ -100,6 +102,14 @@ export class Model<T extends object> {
 		return `CREATE TABLE \`${this.tableName}\` (${columnDefinition.join(
 			", "
 		)});`;
+	}
+
+	private coerceTypedValue(column: ModelColumn): unknown {
+		if (column.type === DataTypes.BOOLEAN) {
+			return Boolean(column.defaultValue).valueOf() ? 1 : 0;
+		} else {
+			return column.defaultValue;
+		}
 	}
 
 	/**

--- a/src/queryBuilder.ts
+++ b/src/queryBuilder.ts
@@ -188,12 +188,14 @@ export function GenerateQuery<T extends object>(
 	};
 }
 
+/** @hidden */
 export function coerceTypedValues(list: Array<unknown>) {
 	for (let i = 0; i < list.length; i++) {
 		list[i] = coerceTypedValue(list[i]);
 	}
 }
 
+/** @hidden */
 export function coerceTypedValue(value: unknown) {
 	if (typeof value === "boolean") {
 		return value ? 1 : 0;

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -155,4 +155,52 @@ describe("Model > Create Tables", () => {
 			'CREATE TABLE `test` (id integer, name text DEFAULT "test", PRIMARY KEY (id));'
 		);
 	});
+	it("should support a default value for boolean string true", () => {
+		const model = new Model(
+			{ D1Orm: orm, tableName: "test" },
+			{
+				id: { type: DataTypes.INTEGER, primaryKey: true },
+				flag: { type: DataTypes.BOOLEAN, defaultValue: "true" },
+			}
+		);
+		expect(model.createTableDefinition).to.equal(
+			'CREATE TABLE `test` (id integer, flag integer DEFAULT "1", PRIMARY KEY (id));'
+		);
+	});
+	it("should support a default value for boolean false", () => {
+		const model = new Model(
+			{ D1Orm: orm, tableName: "test" },
+			{
+				id: { type: DataTypes.INTEGER, primaryKey: true },
+				flag: { type: DataTypes.BOOLEAN, defaultValue: false },
+			}
+		);
+		expect(model.createTableDefinition).to.equal(
+			'CREATE TABLE `test` (id integer, flag integer DEFAULT "0", PRIMARY KEY (id));'
+		);
+	});
+	it("should support a default value for integer 0 false", () => {
+		const model = new Model(
+			{ D1Orm: orm, tableName: "test" },
+			{
+				id: { type: DataTypes.INTEGER, primaryKey: true },
+				flag: { type: DataTypes.BOOLEAN, defaultValue: 0 },
+			}
+		);
+		expect(model.createTableDefinition).to.equal(
+			'CREATE TABLE `test` (id integer, flag integer DEFAULT "0", PRIMARY KEY (id));'
+		);
+	});
+	it("should support a default value for integer 1 true", () => {
+		const model = new Model(
+			{ D1Orm: orm, tableName: "test" },
+			{
+				id: { type: DataTypes.INTEGER, primaryKey: true },
+				flag: { type: DataTypes.BOOLEAN, defaultValue: 1 },
+			}
+		);
+		expect(model.createTableDefinition).to.equal(
+			'CREATE TABLE `test` (id integer, flag integer DEFAULT "1", PRIMARY KEY (id));'
+		);
+	});
 });

--- a/test/querybuilder.test.js
+++ b/test/querybuilder.test.js
@@ -1,28 +1,9 @@
 import { expect } from "chai";
-import { D1Orm } from "../lib/database.js";
-import { DataTypes } from "../lib/datatypes.js";
-import { Model } from "../lib/model.js";
 import {
 	GenerateQuery,
 	QueryType,
 	transformOrderBy,
 } from "../lib/queryBuilder.js";
-
-
-const fakeD1Database = {
-	prepare: () => {},
-	dump: () => {},
-	batch: () => {},
-	exec: () => {},
-};
-const model = new Model(
-	{ D1Orm: new D1Orm(fakeD1Database), tableName: "test" },
-	{
-		id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
-		name: { type: DataTypes.STRING },
-		flag: { type: DataTypes.BOOLEAN },
-	}
-);
 
 describe("Query Builder", () => {
 	describe("Validation of options", () => {
@@ -34,7 +15,7 @@ describe("Query Builder", () => {
 			);
 		});
 		it("should throw an error if query type is invalid", () => {
-			expect(() => GenerateQuery("INVALID", "test", model, () => {})).to.throw(
+			expect(() => GenerateQuery("INVALID", "test", () => {})).to.throw(
 				Error,
 				"Invalid QueryType provided"
 			);
@@ -48,12 +29,12 @@ describe("Query Builder", () => {
 	describe("Query Generation", () => {
 		describe(QueryType.SELECT, () => {
 			it("should generate a basic query", () => {
-				const statement = GenerateQuery(QueryType.SELECT, "test", model);
+				const statement = GenerateQuery(QueryType.SELECT, "test");
 				expect(statement.query).to.equal("SELECT * FROM `test`");
 				expect(statement.bindings).to.be.empty;
 			});
 			it("should generate a query with a where clause", () => {
-				const statement = GenerateQuery(QueryType.SELECT, "test", model, {
+				const statement = GenerateQuery(QueryType.SELECT, "test", {
 					where: { id: 1 },
 				});
 				expect(statement.query).to.equal("SELECT * FROM `test` WHERE id = ?");
@@ -61,7 +42,7 @@ describe("Query Builder", () => {
 				expect(statement.bindings[0]).to.equal(1);
 			});
 			it("should generate a query with a where clause with multiple conditions", () => {
-				const statement = GenerateQuery(QueryType.SELECT, "test", model, {
+				const statement = GenerateQuery(QueryType.SELECT, "test", {
 					where: { id: 1, name: "test" },
 				});
 				expect(statement.query).to.equal(
@@ -72,14 +53,14 @@ describe("Query Builder", () => {
 				expect(statement.bindings[1]).to.equal("test");
 			});
 			it("should generate a query with a limit", () => {
-				const statement = GenerateQuery(QueryType.SELECT, "test", model, {
+				const statement = GenerateQuery(QueryType.SELECT, "test", {
 					limit: 10,
 				});
 				expect(statement.query).to.equal("SELECT * FROM `test` LIMIT 10");
 				expect(statement.bindings).to.be.empty;
 			});
 			it("should generate a query with a limit and offset", () => {
-				const statement = GenerateQuery(QueryType.SELECT, "test", model, {
+				const statement = GenerateQuery(QueryType.SELECT, "test", {
 					limit: 10,
 					offset: 5,
 				});
@@ -89,7 +70,7 @@ describe("Query Builder", () => {
 				expect(statement.bindings).to.be.empty;
 			});
 			it("should generate a query with a limit and offset and order", () => {
-				const statement = GenerateQuery(QueryType.SELECT, "test", model, {
+				const statement = GenerateQuery(QueryType.SELECT, "test", {
 					limit: 10,
 					offset: 5,
 					orderBy: "id",
@@ -100,7 +81,7 @@ describe("Query Builder", () => {
 				expect(statement.bindings).to.be.empty;
 			});
 			it("should accept orderBy as an object", () => {
-				const statement = GenerateQuery(QueryType.SELECT, "test", model, {
+				const statement = GenerateQuery(QueryType.SELECT, "test", {
 					orderBy: { column: "id", descending: true, nullLast: true },
 				});
 				expect(statement.query).to.equal(
@@ -109,7 +90,7 @@ describe("Query Builder", () => {
 				expect(statement.bindings).to.be.empty;
 			});
 			it("should accept orderBy as an array", () => {
-				const statement = GenerateQuery(QueryType.SELECT, "test", model, {
+				const statement = GenerateQuery(QueryType.SELECT, "test", {
 					orderBy: [{ column: "id", descending: true, nullLast: true }, "name"],
 				});
 				expect(statement.query).to.equal(
@@ -118,7 +99,7 @@ describe("Query Builder", () => {
 				expect(statement.bindings).to.be.empty;
 			});
 			it("should generate a query with a where clause with multiple conditions and a limit and offset and order", () => {
-				const statement = GenerateQuery(QueryType.SELECT, "test", model, {
+				const statement = GenerateQuery(QueryType.SELECT, "test", {
 					where: { id: 1, name: "test" },
 					limit: 10,
 					offset: 5,
@@ -132,7 +113,7 @@ describe("Query Builder", () => {
 				expect(statement.bindings[1]).to.equal("test");
 			});
 			it("should ignore an empty where clause object", () => {
-				const statement = GenerateQuery(QueryType.SELECT, "test", model, {
+				const statement = GenerateQuery(QueryType.SELECT, "test", {
 					where: {},
 				});
 				expect(statement.query).to.equal("SELECT * FROM `test`");
@@ -141,12 +122,12 @@ describe("Query Builder", () => {
 		});
 		describe(QueryType.DELETE, () => {
 			it("should generate a basic query", () => {
-				const statement = GenerateQuery(QueryType.DELETE, "test", model);
+				const statement = GenerateQuery(QueryType.DELETE, "test");
 				expect(statement.query).to.equal("DELETE FROM `test`");
 				expect(statement.bindings).to.be.empty;
 			});
 			it("should generate a query with a where clause", () => {
-				const statement = GenerateQuery(QueryType.DELETE, "test", model, {
+				const statement = GenerateQuery(QueryType.DELETE, "test", {
 					where: { id: 1 },
 				});
 				expect(statement.query).to.equal("DELETE FROM `test` WHERE id = ?");
@@ -154,7 +135,7 @@ describe("Query Builder", () => {
 				expect(statement.bindings[0]).to.equal(1);
 			});
 			it("should generate a query with a where clause with multiple conditions", () => {
-				const statement = GenerateQuery(QueryType.DELETE, "test", model, {
+				const statement = GenerateQuery(QueryType.DELETE, "test", {
 					where: { id: 1, name: "test" },
 				});
 				expect(statement.query).to.equal(
@@ -167,17 +148,17 @@ describe("Query Builder", () => {
 		});
 		describe(QueryType.INSERT, () => {
 			it("should throw an error if no data is provided", () => {
-				expect(() => GenerateQuery(QueryType.INSERT, "test", model)).to.throw(
+				expect(() => GenerateQuery(QueryType.INSERT, "test")).to.throw(
 					"Must provide data to insert"
 				);
 			});
 			it("should throw an error if empty data is provided", () => {
 				expect(() =>
-					GenerateQuery(QueryType.INSERT, "test", model, { data: {} })
+					GenerateQuery(QueryType.INSERT, "test", { data: {} })
 				).to.throw("Must provide data to insert");
 			});
 			it("should generate a basic query", () => {
-				const statement = GenerateQuery(QueryType.INSERT, "test", model, {
+				const statement = GenerateQuery(QueryType.INSERT, "test", {
 					data: { id: 1 },
 				});
 				expect(statement.query).to.equal("INSERT INTO `test` (id) VALUES (?)");
@@ -185,42 +166,32 @@ describe("Query Builder", () => {
 				expect(statement.bindings[0]).to.equal(1);
 			});
 			it("should generate a query with multiple columns", () => {
-				const statement = GenerateQuery(QueryType.INSERT, "test", model, {
-					data: { id: 1, name: "test" },
+				const statement = GenerateQuery(QueryType.INSERT, "test", {
+					data: { id: 1, name: "test", flagA: true, flagB: false },
 				});
 				expect(statement.query).to.equal(
-					"INSERT INTO `test` (id, name) VALUES (?, ?)"
+					"INSERT INTO `test` (id, name, flagA, flagB) VALUES (?, ?, ?, ?)"
 				);
-				expect(statement.bindings.length).to.equal(2);
-				expect(statement.bindings[0]).to.equal(1);
-				expect(statement.bindings[1]).to.equal("test");
-			});
-			it("should generate a query with multiple columns and boolean values", () => {
-				const statement = GenerateQuery(QueryType.INSERT, "test", model, {
-					data: { id: 1, name: "test", flag: true },
-				});
-				expect(statement.query).to.equal(
-					"INSERT INTO `test` (id, name, flag) VALUES (?, ?, ?)"
-				);
-				expect(statement.bindings.length).to.equal(3);
+				expect(statement.bindings.length).to.equal(4);
 				expect(statement.bindings[0]).to.equal(1);
 				expect(statement.bindings[1]).to.equal("test");
 				expect(statement.bindings[2]).to.equal(1);
+				expect(statement.bindings[3]).to.equal(0);
 			});
 		});
 		describe(QueryType.INSERT_OR_REPLACE, () => {
 			it("should throw an error if no data is provided", () => {
 				expect(() =>
-					GenerateQuery(QueryType.INSERT_OR_REPLACE, "test", model)
+					GenerateQuery(QueryType.INSERT_OR_REPLACE, "test")
 				).to.throw("Must provide data to insert");
 			});
 			it("should throw an error if empty data is provided", () => {
 				expect(() =>
-					GenerateQuery(QueryType.INSERT_OR_REPLACE, "test", model, { data: {} })
+					GenerateQuery(QueryType.INSERT_OR_REPLACE, "test", { data: {} })
 				).to.throw("Must provide data to insert");
 			});
 			it("should generate a basic query", () => {
-				const statement = GenerateQuery(QueryType.INSERT_OR_REPLACE, "test", model, {
+				const statement = GenerateQuery(QueryType.INSERT_OR_REPLACE, "test", {
 					data: { id: 1 },
 				});
 				expect(statement.query).to.equal(
@@ -230,7 +201,7 @@ describe("Query Builder", () => {
 				expect(statement.bindings[0]).to.equal(1);
 			});
 			it("should generate a query with multiple columns", () => {
-				const statement = GenerateQuery(QueryType.INSERT_OR_REPLACE, "test", model, {
+				const statement = GenerateQuery(QueryType.INSERT_OR_REPLACE, "test", {
 					data: { id: 1, name: "test" },
 				});
 				expect(statement.query).to.equal(
@@ -243,17 +214,17 @@ describe("Query Builder", () => {
 		});
 		describe(QueryType.UPDATE, () => {
 			it("should throw an error if no data is provided", () => {
-				expect(() => GenerateQuery(QueryType.UPDATE, "test", model)).to.throw(
+				expect(() => GenerateQuery(QueryType.UPDATE, "test")).to.throw(
 					"Must provide data to update"
 				);
 			});
 			it("should throw an error if empty data is provided", () => {
 				expect(() =>
-					GenerateQuery(QueryType.UPDATE, "test", model, { data: {} })
+					GenerateQuery(QueryType.UPDATE, "test", { data: {} })
 				).to.throw("Must provide data to update");
 			});
 			it("should generate a basic query", () => {
-				const statement = GenerateQuery(QueryType.UPDATE, "test", model, {
+				const statement = GenerateQuery(QueryType.UPDATE, "test", {
 					data: { id: 1 },
 				});
 				expect(statement.query).to.equal("UPDATE `test` SET id = ?");
@@ -261,7 +232,7 @@ describe("Query Builder", () => {
 				expect(statement.bindings[0]).to.equal(1);
 			});
 			it("should generate a query with multiple columns", () => {
-				const statement = GenerateQuery(QueryType.UPDATE, "test", model, {
+				const statement = GenerateQuery(QueryType.UPDATE, "test", {
 					data: { id: 1, name: "test" },
 				});
 				expect(statement.query).to.equal("UPDATE `test` SET id = ?, name = ?");
@@ -270,7 +241,7 @@ describe("Query Builder", () => {
 				expect(statement.bindings[1]).to.equal("test");
 			});
 			it("should generate a query with a where clause", () => {
-				const statement = GenerateQuery(QueryType.UPDATE, "test", model, {
+				const statement = GenerateQuery(QueryType.UPDATE, "test", {
 					data: { name: "test" },
 					where: { id: 1 },
 				});
@@ -282,7 +253,7 @@ describe("Query Builder", () => {
 				expect(statement.bindings[1]).to.equal(1);
 			});
 			it("should generate a query with a where clause with multiple conditions", () => {
-				const statement = GenerateQuery(QueryType.UPDATE, "test", model, {
+				const statement = GenerateQuery(QueryType.UPDATE, "test", {
 					data: { name: "test" },
 					where: { id: 1, name: "test" },
 				});
@@ -297,18 +268,18 @@ describe("Query Builder", () => {
 		});
 		describe(QueryType.UPSERT, () => {
 			it("should throw an error if invalid options are provided", () => {
-				expect(() => GenerateQuery(QueryType.UPSERT, "test", model)).to.throw(
+				expect(() => GenerateQuery(QueryType.UPSERT, "test")).to.throw(
 					"Must provide data to insert with, data to update with, and where keys in Upsert"
 				);
 				expect(() =>
-					GenerateQuery(QueryType.UPSERT, "test", model, {
+					GenerateQuery(QueryType.UPSERT, "test", {
 						data: { id: 1 },
 					})
 				).to.throw(
 					"Must provide data to insert with, data to update with, and where keys in Upsert"
 				);
 				expect(() =>
-					GenerateQuery(QueryType.UPSERT, "test", model, {
+					GenerateQuery(QueryType.UPSERT, "test", {
 						data: { id: 1 },
 						where: { id: 1 },
 					})
@@ -316,7 +287,7 @@ describe("Query Builder", () => {
 					"Must provide data to insert with, data to update with, and where keys in Upsert"
 				);
 				expect(() =>
-					GenerateQuery(QueryType.UPSERT, "test", model, {
+					GenerateQuery(QueryType.UPSERT, "test", {
 						data: { id: 1 },
 						where: { id: 1 },
 						upsertOnlyUpdateData: { id: 1 },
@@ -324,21 +295,22 @@ describe("Query Builder", () => {
 				).to.not.throw();
 			});
 			it("should generate a basic query", () => {
-				const statement = GenerateQuery(QueryType.UPSERT, "test", model, {
-					data: { id: 1 },
+				const statement = GenerateQuery(QueryType.UPSERT, "test", {
+					data: { id: 1, flag: true },
 					upsertOnlyUpdateData: { id: 2 },
 					where: { id: 3 },
 				});
 				expect(statement.query).to.equal(
-					"INSERT INTO `test` (id) VALUES (?) ON CONFLICT (id) DO UPDATE SET id = ? WHERE id = ?"
+					"INSERT INTO `test` (id, flag) VALUES (?, ?) ON CONFLICT (id) DO UPDATE SET id = ? WHERE id = ?"
 				);
-				expect(statement.bindings.length).to.equal(3);
+				expect(statement.bindings.length).to.equal(4);
 				expect(statement.bindings[0]).to.equal(1);
-				expect(statement.bindings[1]).to.equal(2);
-				expect(statement.bindings[2]).to.equal(3);
+				expect(statement.bindings[1]).to.equal(1);
+				expect(statement.bindings[2]).to.equal(2);
+				expect(statement.bindings[3]).to.equal(3);
 			});
 			it("should generate a query with multiple columns", () => {
-				const statement = GenerateQuery(QueryType.UPSERT, "test", model, {
+				const statement = GenerateQuery(QueryType.UPSERT, "test", {
 					data: { id: 1, name: "test" },
 					upsertOnlyUpdateData: { id: 1, name: "test" },
 					where: { id: 1 },
@@ -356,7 +328,7 @@ describe("Query Builder", () => {
 			it("should generate a query with a different ON CONFLICT key", () => {
 				const statement = GenerateQuery(
 					QueryType.UPSERT,
-					"test", model,
+					"test",
 
 					{
 						data: { id: 1, name: "test" },
@@ -378,7 +350,7 @@ describe("Query Builder", () => {
 			it("should accept multiple primary keys", () => {
 				const statement = GenerateQuery(
 					QueryType.UPSERT,
-					"test", model,
+					"test",
 					{
 						data: { id: 1, name: "test" },
 						upsertOnlyUpdateData: { id: 1, name: "test" },


### PR DESCRIPTION
Sqlite supports a boolean datatype which gets automatically coerced into a 0 or 1. 

The new datatype was added, along with type coercion to support all the query types.

The change to support this ends up being fairly trivial, but I would love feedback and any thoughts on the implementation or suggestions on alteration.

I think this implementation sets it up to allow other types of coercion with even less updates.  