### PR TITLE
Add support for passing a unique column to queryBuilder for UPSERT st…

### DIFF
--- a/src/queryBuilder.ts
+++ b/src/queryBuilder.ts
@@ -32,6 +32,7 @@ export type GenerateQueryOptions<T extends object> = {
 	orderBy?: OrderBy<T> | OrderBy<T>[];
 	data?: Partial<T>;
 	upsertOnlyUpdateData?: Partial<T>;
+	uniqueColumn?: string;
 };
 
 /**
@@ -171,9 +172,10 @@ export function GenerateQuery<T extends object>(
 				.split("")
 				.join(", ")})`;
 
-			const primaryKeyStr = Array.isArray(primaryKeys)
+			const primaryKeyStr = options.uniqueColumn || (Array.isArray(primaryKeys)
 				? primaryKeys.join(", ")
-				: primaryKeys;
+				: primaryKeys);
+
 			query += ` ON CONFLICT (${primaryKeyStr}) DO UPDATE SET`;
 			query += ` ${updateDataKeys.map((key) => `${key} = ?`).join(", ")}`;
 			query += ` WHERE ${whereKeys.map((key) => `${key} = ?`).join(" AND ")}`;

--- a/test/querybuilder.test.js
+++ b/test/querybuilder.test.js
@@ -291,6 +291,15 @@ describe("Query Builder", () => {
 						upsertOnlyUpdateData: { id: 1 },
 					})
 				).to.not.throw();
+
+				expect(() =>
+					GenerateQuery(QueryType.UPSERT, "test", {
+						data: { id: 1 },
+						where: { id: 1 },
+						upsertOnlyUpdateData: { id: 1 },
+						uniqueColumn: 'email'
+					})
+				).to.not.throw();
 			});
 			it("should generate a basic query", () => {
 				const statement = GenerateQuery(QueryType.UPSERT, "test", {


### PR DESCRIPTION
The default primary key does work but is not suitable for all situations, there are use cases that need an email or an api key to be used as the conflicting column. 

