### PR TITLE
Fix README as Model Options property name

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ export default {
 			{
 				D1Orm: orm,
 				tableName: "users",
-				primaryKey: "id",
+				primaryKeys: "id",
 				autoIncrement: "id",
 				uniqueKeys: [["email"]],
 			},


### PR DESCRIPTION
In `README.md`, the Model options propety name `primaryKeys` is incorrect, which is now `primaryKey`.
I fixed it.

Resource: https://github.com/Interactions-as-a-Service/d1-orm/blob/e418a4f7455652853df951d1da6d8ca447d24391/src/model.ts#L22