### PR TITLE
JSON support proposal, currently only for INSERT

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -5,7 +5,7 @@ import type { GenerateQueryOptions } from "./queryBuilder.js";
 /**
  * @typeParam T - The type of the model, which will be returned when using methods such as First() or All()
  */
-export class Model<T extends Record<string, ModelColumn>> {
+export class Model<T extends ModelColumns> {
 	/**
 	 * @param options - The options for the model. All parameters except autoIncrement and uniqueKeys are required.
 	 * @param options.tableName - The name of the table to use.
@@ -195,7 +195,10 @@ export class Model<T extends Record<string, ModelColumn>> {
 		orReplace = false
 	): Promise<D1Result<InferFromColumns<T>>> {
 		const qt = orReplace ? QueryType.INSERT_OR_REPLACE : QueryType.INSERT;
-		const statement = GenerateQuery(qt, this.tableName, { data });
+		const statement = GenerateQuery(qt, this.tableName, {
+			data,
+			columns: this.columns,
+		});
 		return this.D1Orm.prepare(statement.query)
 			.bind(...statement.bindings)
 			.run();
@@ -315,7 +318,9 @@ export interface ModelColumn {
 	type: DataTypes;
 	notNull?: boolean;
 	defaultValue?: unknown;
+	json?: boolean;
 }
+export type ModelColumns = Record<string, ModelColumn>;
 
 /**
  * @enum {string} Aliases for DataTypes used in a {@link ModelColumn} definition.

--- a/test/querybuilder.test.js
+++ b/test/querybuilder.test.js
@@ -176,6 +176,26 @@ describe("Query Builder", () => {
 				expect(statement.bindings[0]).to.equal(1);
 				expect(statement.bindings[1]).to.equal("test");
 			});
+			it("can write JSON with a column config", () => {
+				const address = { line1: '1000 N. Main St.', city: 'New York', state: 'NY' }
+				const statement = GenerateQuery(QueryType.INSERT, "test", {
+					data: {
+						id: 1,
+						name: "test",
+						address
+					},
+					columns: {
+						address: { type: 'text', json: true }
+					}
+				});
+				expect(statement.query).to.equal(
+					"INSERT INTO `test` (id, name, address) VALUES (?, ?, json(?))"
+				);
+				expect(statement.bindings.length).to.equal(3);
+				expect(statement.bindings[0]).to.equal(1);
+				expect(statement.bindings[1]).to.equal("test");
+				expect(statement.bindings[2]).to.equal(JSON.stringify(address));
+			});
 		});
 		describe(QueryType.INSERT_OR_REPLACE, () => {
 			it("should throw an error if no data is provided", () => {
@@ -208,6 +228,26 @@ describe("Query Builder", () => {
 				expect(statement.bindings.length).to.equal(2);
 				expect(statement.bindings[0]).to.equal(1);
 				expect(statement.bindings[1]).to.equal("test");
+			});
+			it("can write JSON with a column config", () => {
+				const address = { line1: '1000 N. Main St.', city: 'New York', state: 'NY' }
+				const statement = GenerateQuery(QueryType.INSERT_OR_REPLACE, "test", {
+					data: {
+						id: 1,
+						name: "test",
+						address
+					},
+					columns: {
+						address: { type: 'text', json: true }
+					}
+				});
+				expect(statement.query).to.equal(
+					"INSERT or REPLACE INTO `test` (id, name, address) VALUES (?, ?, json(?))"
+				);
+				expect(statement.bindings.length).to.equal(3);
+				expect(statement.bindings[0]).to.equal(1);
+				expect(statement.bindings[1]).to.equal("test");
+				expect(statement.bindings[2]).to.equal(JSON.stringify(address));
 			});
 		});
 		describe(QueryType.UPDATE, () => {


### PR DESCRIPTION
## Purpose

This is the beginning of a proposal/spec for supporting JSON.  The goal was to reveal a pattern that can be applied to other Model and QueryBuilder methods.  I'd like to get opinions before I commit to the remaining query methods.

## Context

JSON support requires some sort of schema because it uses a `TEXT` column type, but requires additional context/knowledge that the column should be treated as JSON. With this in mind, the QueryBuilder has been updated to accept an optional `columns` property in the options.

## Changes to note

- [x] adds a `json` boolean to the `ModelColumn` interface.
- [x] adds an optional `columns` config to the `GenerateQueryOptions`
- [x] updates the query builder for `INSERT` and `INSERT_OR_REPLACE` to check for a column config and give special treatment if `column.json` is truthy.
- [x] updates the `Model.InsertOne` method to pass `columns` in the options.
- [x] updates QueryBuilder tests to show that queries are correctly formed.