### PR TITLE
Add `WITHOUT ROWID` support

### DIFF
--- a/.changeset/quick-cups-fix.md
+++ b/.changeset/quick-cups-fix.md
@@ -2,4 +2,4 @@
 "d1-orm": minor
 ---
 
-add WITHOUT ROWID support(opt-out)
+Adds a `withRowId` option to the Model class, defaulting to false. When not set to `true`, the `Model.createTableDefinition` will now include a `WITHOUT ROWID` line, which can optimise the performance of a majority of tables.

--- a/.changeset/quick-cups-fix.md
+++ b/.changeset/quick-cups-fix.md
@@ -1,0 +1,5 @@
+---
+"d1-orm": minor
+---
+
+add WITHOUT ROWID support(opt-out)

--- a/src/model.ts
+++ b/src/model.ts
@@ -7,7 +7,7 @@ import type { GenerateQueryOptions } from "./queryBuilder.js";
  */
 export class Model<T extends Record<string, ModelColumn>> {
 	/**
-	 * @param options - The options for the model. All parameters except autoIncrement and uniqueKeys are required.
+	 * @param options - The options for the model. All parameters except autoIncrement, withRowId, and uniqueKeys are required.
 	 * @param options.tableName - The name of the table to use.
 	 * @param options.D1Orm - The D1Orm instance to use - optional. If not set initially, you must use SetOrm() to set before querying.
 	 * @param options.primaryKeys - The primary key or keys of the table.

--- a/src/model.ts
+++ b/src/model.ts
@@ -55,8 +55,10 @@ export class Model<T extends Record<string, ModelColumn>> {
 			);
 		}
 
-		if(this.#withRowId && this.#autoIncrementColumn) {
-			throw new Error("Options.autoIncrement and Options.withRowId cannot both be set");
+		if (this.#withRowId && this.#autoIncrementColumn) {
+			throw new Error(
+				"Options.autoIncrement and Options.withRowId cannot both be set"
+			);
 		}
 
 		if (!columns) {
@@ -158,7 +160,9 @@ export class Model<T extends Record<string, ModelColumn>> {
 		}
 		return `CREATE TABLE \`${this.tableName}\` (${columnDefinition.join(
 			", "
-		)})${this.#autoIncrementColumn || this.#withRowId ? "" : " WITHOUT ROWID"};`;
+		)})${
+			this.#autoIncrementColumn || this.#withRowId ? "" : " WITHOUT ROWID"
+		};`;
 	}
 
 	/**

--- a/src/model.ts
+++ b/src/model.ts
@@ -149,7 +149,7 @@ export class Model<T extends Record<string, ModelColumn>> {
 		}
 		return `CREATE TABLE \`${this.tableName}\` (${columnDefinition.join(
 			", "
-		)});`;
+		)})${this.#autoIncrementColumn ? "" : " WITHOUT ROWID"};`;
 	}
 
 	/**

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -191,7 +191,7 @@ describe("Model > Create Tables", () => {
 			}
 		);
 		expect(model.createTableDefinition).to.equal(
-			"CREATE TABLE `test` (id integer, name text, PRIMARY KEY (id, name));"
+			"CREATE TABLE `test` (id integer, name text, PRIMARY KEY (id, name)) WITHOUT ROWID;"
 		);
 	});
 	it("should support a not null constraint", () => {
@@ -203,7 +203,7 @@ describe("Model > Create Tables", () => {
 			}
 		);
 		expect(model.createTableDefinition).to.equal(
-			"CREATE TABLE `test` (id integer, name text NOT NULL, PRIMARY KEY (id));"
+			"CREATE TABLE `test` (id integer, name text NOT NULL, PRIMARY KEY (id)) WITHOUT ROWID;"
 		);
 	});
 	it("should support a valid autoIncrement constraint", () => {
@@ -233,7 +233,7 @@ describe("Model > Create Tables", () => {
 				}
 			);
 			expect(model.createTableDefinition).to.equal(
-				"CREATE TABLE `test` (id integer, name text, PRIMARY KEY (id), UNIQUE (id));"
+				"CREATE TABLE `test` (id integer, name text, PRIMARY KEY (id), UNIQUE (id)) WITHOUT ROWID;"
 			);
 		});
 		it("should support multiple unique constraints", () => {
@@ -250,7 +250,7 @@ describe("Model > Create Tables", () => {
 				}
 			);
 			expect(model.createTableDefinition).to.equal(
-				"CREATE TABLE `test` (id integer, name text, PRIMARY KEY (id), UNIQUE (id), UNIQUE (name));"
+				"CREATE TABLE `test` (id integer, name text, PRIMARY KEY (id), UNIQUE (id), UNIQUE (name)) WITHOUT ROWID;"
 			);
 		});
 		it("should support a unique constraint with multiple columns", () => {
@@ -267,7 +267,7 @@ describe("Model > Create Tables", () => {
 				}
 			);
 			expect(model.createTableDefinition).to.equal(
-				"CREATE TABLE `test` (id integer, name text, PRIMARY KEY (id), UNIQUE (id, name));"
+				"CREATE TABLE `test` (id integer, name text, PRIMARY KEY (id), UNIQUE (id, name)) WITHOUT ROWID;"
 			);
 		});
 	});
@@ -281,7 +281,7 @@ describe("Model > Create Tables", () => {
 				}
 			);
 			expect(model.createTableDefinition).to.equal(
-				"CREATE TABLE `test` (id integer, is_admin text DEFAULT 'test', PRIMARY KEY (id));"
+				"CREATE TABLE `test` (id integer, is_admin text DEFAULT 'test', PRIMARY KEY (id)) WITHOUT ROWID;"
 			);
 		});
 		it("should support a number", () => {
@@ -293,7 +293,7 @@ describe("Model > Create Tables", () => {
 				}
 			);
 			expect(model.createTableDefinition).to.equal(
-				"CREATE TABLE `test` (id integer, is_admin integer DEFAULT 1, PRIMARY KEY (id));"
+				"CREATE TABLE `test` (id integer, is_admin integer DEFAULT 1, PRIMARY KEY (id)) WITHOUT ROWID;"
 			);
 		});
 		it("should support a boolean", () => {
@@ -305,7 +305,7 @@ describe("Model > Create Tables", () => {
 				}
 			);
 			expect(model.createTableDefinition).to.equal(
-				"CREATE TABLE `test` (id integer, is_admin boolean DEFAULT true, PRIMARY KEY (id));"
+				"CREATE TABLE `test` (id integer, is_admin boolean DEFAULT true, PRIMARY KEY (id)) WITHOUT ROWID;"
 			);
 		});
 	});

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -24,6 +24,24 @@ describe("Model Validation", () => {
 				"Options.tableName must be a string"
 			);
 		});
+		it("should throw if autoincrement and withRowId are both set", () => {
+			expect(
+				() =>
+					new Model(
+						{
+							D1Orm: orm,
+							tableName: "users",
+							primaryKeys: "id",
+							autoIncrement: "id",
+							withRowId: true,
+						},
+						{ id: { type: DataTypes.INTEGER } }
+					)
+			).to.throw(
+				Error,
+				"Options.autoIncrement and Options.withRowId cannot both be set"
+			);
+		});
 		describe("Primary keys", () => {
 			it("should throw an error if no primary keys are provided", () => {
 				expect(() => new Model({ D1Orm: orm, tableName: "users" })).to.throw(
@@ -216,6 +234,18 @@ describe("Model > Create Tables", () => {
 		);
 		expect(model.createTableDefinition).to.equal(
 			"CREATE TABLE `test` (id integer PRIMARY KEY AUTOINCREMENT, name text);"
+		);
+	});
+	it("should not include WITHOUT ROWID", () => {
+		const model = new Model(
+			{ D1Orm: orm, tableName: "test", primaryKeys: "id", withRowId: true },
+			{
+				id: { type: DataTypes.INTEGER },
+				is_admin: { type: DataTypes.STRING },
+			}
+		);
+		expect(model.createTableDefinition).to.equal(
+			"CREATE TABLE `test` (id integer, is_admin text, PRIMARY KEY (id));"
 		);
 	});
 	describe("Unique Constraints", () => {


### PR DESCRIPTION
Add support for the `WITHOUT ROWID` clause.
Will error when conflicts are detected with `AUTOINCREMENT`.