### PR TITLE
feat: update to latest D1 Database interface

### DIFF
--- a/.changeset/happy-seas-check.md
+++ b/.changeset/happy-seas-check.md
@@ -1,0 +1,5 @@
+---
+"d1-orm": minor
+---
+
+This introduces breaking changes by updating to the latest `@cloudflare/workers-types@^4.20231025.0`, including compatability changes for the D1Database `exec` API. Namely, the model methods `CreateTable` and `DropTable` now return a `D1ExecResult` instead of `D1Result`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,10 @@
 			"devDependencies": {
 				"@changesets/changelog-github": "^0.4.7",
 				"@changesets/cli": "^2.25.0",
-				"@cloudflare/workers-types": "^3.17.0",
+				"@cloudflare/workers-types": "^4.20231025.0",
 				"@types/mocha": "^10.0.0",
 				"@typescript-eslint/eslint-plugin": "^5.40.0",
-				"chai": "^4.3.6",
+				"chai": "^4.3.10",
 				"eslint-plugin-import": "^2.26.0",
 				"eslint-plugin-unused-imports": "^2.0.0",
 				"mocha": "^10.1.0",
@@ -785,9 +785,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workers-types": {
-			"version": "3.17.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-3.17.0.tgz",
-			"integrity": "sha512-u0cUQ4ntWFFwn5jx0ETa2ItvwvfOMjyaKF2fX2vFVujrSgNES/PnvRzPAhdt9CMYAMidInm0MGkIjxHRsFBaeg==",
+			"version": "4.20231025.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20231025.0.tgz",
+			"integrity": "sha512-TkcZkntUTOcvJ4vgmwpNfLTclpMbmbClZCe62B25/VTukmyv91joRa4eKzSjzCZUXTbFHNmVdOpmGaaJU2U3+A==",
 			"dev": true
 		},
 		"node_modules/@esbuild-plugins/node-globals-polyfill": {
@@ -2131,18 +2131,18 @@
 			}
 		},
 		"node_modules/chai": {
-			"version": "4.3.6",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
-			"integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
+			"version": "4.3.10",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.10.tgz",
+			"integrity": "sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g==",
 			"dev": true,
 			"dependencies": {
 				"assertion-error": "^1.1.0",
-				"check-error": "^1.0.2",
-				"deep-eql": "^3.0.1",
-				"get-func-name": "^2.0.0",
-				"loupe": "^2.3.1",
+				"check-error": "^1.0.3",
+				"deep-eql": "^4.1.3",
+				"get-func-name": "^2.0.2",
+				"loupe": "^2.3.6",
 				"pathval": "^1.1.1",
-				"type-detect": "^4.0.5"
+				"type-detect": "^4.0.8"
 			},
 			"engines": {
 				"node": ">=4"
@@ -2171,10 +2171,13 @@
 			"dev": true
 		},
 		"node_modules/check-error": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-			"integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+			"integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
 			"dev": true,
+			"dependencies": {
+				"get-func-name": "^2.0.2"
+			},
 			"engines": {
 				"node": "*"
 			}
@@ -2373,15 +2376,15 @@
 			}
 		},
 		"node_modules/deep-eql": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-			"integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+			"integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
 			"dev": true,
 			"dependencies": {
 				"type-detect": "^4.0.0"
 			},
 			"engines": {
-				"node": ">=0.12"
+				"node": ">=6"
 			}
 		},
 		"node_modules/deep-is": {
@@ -3589,9 +3592,9 @@
 			}
 		},
 		"node_modules/get-func-name": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-			"integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+			"integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
 			"dev": true,
 			"engines": {
 				"node": "*"
@@ -4412,12 +4415,12 @@
 			}
 		},
 		"node_modules/loupe": {
-			"version": "2.3.4",
-			"resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
-			"integrity": "sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==",
+			"version": "2.3.7",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+			"integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
 			"dev": true,
 			"dependencies": {
-				"get-func-name": "^2.0.0"
+				"get-func-name": "^2.0.1"
 			}
 		},
 		"node_modules/lru-cache": {
@@ -7565,9 +7568,9 @@
 			}
 		},
 		"@cloudflare/workers-types": {
-			"version": "3.17.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-3.17.0.tgz",
-			"integrity": "sha512-u0cUQ4ntWFFwn5jx0ETa2ItvwvfOMjyaKF2fX2vFVujrSgNES/PnvRzPAhdt9CMYAMidInm0MGkIjxHRsFBaeg==",
+			"version": "4.20231025.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20231025.0.tgz",
+			"integrity": "sha512-TkcZkntUTOcvJ4vgmwpNfLTclpMbmbClZCe62B25/VTukmyv91joRa4eKzSjzCZUXTbFHNmVdOpmGaaJU2U3+A==",
 			"dev": true
 		},
 		"@esbuild-plugins/node-globals-polyfill": {
@@ -8546,18 +8549,18 @@
 			}
 		},
 		"chai": {
-			"version": "4.3.6",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
-			"integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
+			"version": "4.3.10",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.10.tgz",
+			"integrity": "sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g==",
 			"dev": true,
 			"requires": {
 				"assertion-error": "^1.1.0",
-				"check-error": "^1.0.2",
-				"deep-eql": "^3.0.1",
-				"get-func-name": "^2.0.0",
-				"loupe": "^2.3.1",
+				"check-error": "^1.0.3",
+				"deep-eql": "^4.1.3",
+				"get-func-name": "^2.0.2",
+				"loupe": "^2.3.6",
 				"pathval": "^1.1.1",
-				"type-detect": "^4.0.5"
+				"type-detect": "^4.0.8"
 			}
 		},
 		"chalk": {
@@ -8577,10 +8580,13 @@
 			"dev": true
 		},
 		"check-error": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-			"integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
-			"dev": true
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+			"integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+			"dev": true,
+			"requires": {
+				"get-func-name": "^2.0.2"
+			}
 		},
 		"chokidar": {
 			"version": "3.5.3",
@@ -8735,9 +8741,9 @@
 			}
 		},
 		"deep-eql": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-			"integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+			"integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
 			"dev": true,
 			"requires": {
 				"type-detect": "^4.0.0"
@@ -9570,9 +9576,9 @@
 			"dev": true
 		},
 		"get-func-name": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-			"integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+			"integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
 			"dev": true
 		},
 		"get-intrinsic": {
@@ -10170,12 +10176,12 @@
 			}
 		},
 		"loupe": {
-			"version": "2.3.4",
-			"resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
-			"integrity": "sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==",
+			"version": "2.3.7",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+			"integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
 			"dev": true,
 			"requires": {
-				"get-func-name": "^2.0.0"
+				"get-func-name": "^2.0.1"
 			}
 		},
 		"lru-cache": {

--- a/package.json
+++ b/package.json
@@ -115,10 +115,10 @@
 	"devDependencies": {
 		"@changesets/changelog-github": "^0.4.7",
 		"@changesets/cli": "^2.25.0",
-		"@cloudflare/workers-types": "^3.17.0",
+		"@cloudflare/workers-types": "^4.20231025.0",
 		"@types/mocha": "^10.0.0",
 		"@typescript-eslint/eslint-plugin": "^5.40.0",
-		"chai": "^4.3.6",
+		"chai": "^4.3.10",
 		"eslint-plugin-import": "^2.26.0",
 		"eslint-plugin-unused-imports": "^2.0.0",
 		"mocha": "^10.1.0",

--- a/src/database.ts
+++ b/src/database.ts
@@ -29,8 +29,8 @@ export class D1Orm implements D1Database {
 		return this.database.batch<T>(statements);
 	}
 
-	public async exec<T>(query: string): Promise<D1Result<T>> {
-		return this.database.exec<T>(query);
+	public async exec(query: string): Promise<D1ExecResult> {
+		return this.database.exec(query);
 	}
 }
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -177,7 +177,7 @@ export class Model<T extends Record<string, ModelColumn>> {
 		options: { strategy: "default" | "force" /* | alter */ } = {
 			strategy: "default",
 		}
-	): Promise<D1Result<unknown>> {
+	): Promise<D1ExecResult> {
 		const { strategy } = options;
 		// @ts-expect-error Alter is not yet implemented
 		if (strategy === "alter") {
@@ -193,7 +193,7 @@ export class Model<T extends Record<string, ModelColumn>> {
 	/**
 	 * @param silent If true, will ignore the table not existing. If false, will throw an error if the table does not exist.
 	 */
-	public async DropTable(silent?: boolean): Promise<D1Result<unknown>> {
+	public async DropTable(silent?: boolean): Promise<D1ExecResult> {
 		if (silent) {
 			return this.D1Orm.exec(`DROP TABLE IF EXISTS ${this.tableName};`);
 		}


### PR DESCRIPTION
## Summary

The D1 Database `exec` method has changed an now expects a `ExecResult` instead of a `Result<T>`. If you're using the latest `@cloudflare/workers-types`, the ORM response will be incorrect for methods like `CreateTable` or `DropTable`, which use `exec` under the hood. This PR bumps to the latest version and makes slight changes to fix this return type.

## Details

The latest D1 APIs can be found [here](https://github.com/cloudflare/workerd/blob/main/types/defines/d1.d.ts). The is what `exec` looks like:

```ts
exec(query: string): Promise<D1ExecResult>;
```

And `D1ExecResult`:

```ts
interface D1ExecResult {
  count: number;
  duration: number;
}
```

The proposed changes simply swap out the outdated return type of `D1Result<T>` for `D1ExecResult` where needed. Also, `chai` was updated in order to fix an import issue in the tests.

## How it was tested

After updating these deps and making slight changes to `database.ts` and `model.ts`, the tests pass without needing any changes.